### PR TITLE
Feature/GitHub metrics

### DIFF
--- a/ansible/host_vars/prometheus/vars
+++ b/ansible/host_vars/prometheus/vars
@@ -6,3 +6,4 @@ pip_install_packages:
   - name: botocore
     version: "1.17.56"
 
+github_exporter_tag: "release-1.0.2"

--- a/ansible/host_vars/prometheus/vars
+++ b/ansible/host_vars/prometheus/vars
@@ -5,5 +5,7 @@ pip_install_packages:
     version: "1.14.56"
   - name: botocore
     version: "1.17.56"
+  - name: docker-py
+    version: "1.10.6"
 
 github_exporter_tag: "release-1.0.2"

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -6,5 +6,7 @@
     - mounted-volume
     - epel
     - pip
+    - docker-requirements
+    - docker
     - prometheus-server
     - prometheus-github-exporter

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -7,3 +7,4 @@
     - epel
     - pip
     - prometheus-server
+    - prometheus-github-exporter

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -11,3 +11,7 @@
 - src: https://github.com/geerlingguy/ansible-role-pip
   name: pip
   version: "2.0.0"
+
+- src: https://github.com/geerlingguy/ansible-role-docker
+  name: docker
+  version: "2.9.0"

--- a/ansible/roles/docker-requirements/tasks/main.yml
+++ b/ansible/roles/docker-requirements/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: Ensure iptables is installed
+  become: true
+  become_user: root
+  package:
+    name: iptables
+    state: present
+  when:
+     - ansible_distribution == "CentOS"
+     - ansible_distribution_major_version == "8"

--- a/ansible/roles/prometheus-github-exporter/tasks/main.yml
+++ b/ansible/roles/prometheus-github-exporter/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Verify service groups exists
+  group:
+    name: githubexporter
+    state: present
+
+- name: Verify service user exists
+  user:
+    name: githubexporter
+    shell: /sbin/nologin
+    groups:
+      - githubexporter
+      - docker
+    append: yes
+
+- name: Download the container
+  become_user: githubexporter
+  become: yes
+  docker_container:
+    image: "infinityworks/github-exporter:{{ github_exporter_tag }}"
+    name: github-exporter
+    exposed_ports: "9171"
+    state: stopped
+    user: githubexporter


### PR DESCRIPTION
**Add Github Exporter**
Includes the following additions:
- Add geerlingguy Docker Ansible role.
- Also includes `iptables`, required for Docker on Centos 8.
- Create Github Exporter service user, etc.
- Pull Github Exporter image. Configure as stopped by default for AMI.

Resolves: DVOP-1592