### PR TITLE
Pin docker_package version to docker-ce-19.03.14

### DIFF
--- a/ansible/host_vars/prometheus/vars
+++ b/ansible/host_vars/prometheus/vars
@@ -9,3 +9,5 @@ pip_install_packages:
     version: "1.10.6"
 
 github_exporter_tag: "release-1.0.2"
+
+docker_package: docker-ce-19.03.14


### PR DESCRIPTION
Pin docker_package version to docker-ce-19.03.14
Resolves: DVOP-1629

Resolves error:
amazon-ebs.builder: TASK [docker : Install Docker.]
amazon-ebs.builder: fatal: [prometheus]: FAILED! => {"changed": false, "failures": [], "msg": "Depsolve Error occured: \n Problem: package docker-ce-3:20.10.0-3.el8.x86_64 requires docker-ce-rootless-extras, but none of the providers can be installed\n  - package docker-ce-rootless-extras-20.10.0-3.el8.x86_64 requires slirp4netns >= 0.4, but none of the providers can be installed\n  - cannot install the best candidate for the job\n  - package slirp4netns-0.4.2-3.git21fdece.module_el8.3.0+479+69e2ae26.x86_64 is filtered out by modular filtering\n  - package slirp4netns-1.1.4-2.module_el8.3.0+475+c50ce30b.x86_64 is filtered out by modular filtering", "rc": 1, "results": []}

Workaround documented here:
geerlingguy/ansible-role-docker#243

