### PR TITLE
Add AMI account IDs and decrease data_volume_size

### DIFF
--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -1,5 +1,6 @@
 source "amazon-ebs" "builder" {
   ami_name             = "${var.ami_name_prefix}-${var.version}"
+  ami_users             = var.ami_account_ids  
   communicator         = "ssh"
   instance_type        = var.aws_instance_type
   region               = var.aws_region

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -1,6 +1,6 @@
 source "amazon-ebs" "builder" {
   ami_name             = "${var.ami_name_prefix}-${var.version}"
-  ami_users             = var.ami_account_ids  
+  ami_users             = var.ami_account_ids
   communicator         = "ssh"
   instance_type        = var.aws_instance_type
   region               = var.aws_region

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -1,3 +1,8 @@
+variable "ami_account_ids" {
+  type        = list(string)
+  description = "A list of account IDs that have access to launch the resulting AMI(s)"
+}
+
 variable "ami_name_prefix" {
   type        = string
   default     = "prometheus-ami"
@@ -63,7 +68,7 @@ variable "root_volume_size_gb" {
 
 variable "data_volume_size_gb" {
   type        = number
-  default     = 100
+  default     = 20
   description = "The EC2 instance data volume size in Gibibytes (GiB)"
 }
 


### PR DESCRIPTION
Add AMI account IDs for sharing AMI with other AWS accounts.

Decrease `data_volume_size_gb` from 100gb to 20gb.